### PR TITLE
Manually adds new Westpac BSBs to DB until APN updates

### DIFF
--- a/config/bsb_db.json
+++ b/config/bsb_db.json
@@ -136996,5 +136996,526 @@
     "NSW",
     "2000",
     " EH"
+  ],
+   "032317": [
+    "WBC",
+    "Glendale",
+    "Shop 50a Stockland Shp Cntr",
+    "Glendale",
+    "2285",
+    "NSW",
+    "PEH"
+  ],
+  "033004": [
+    "WBC",
+    "Waverley Gardens",
+    "Shops T5 & 6 Waverley Gardens S/C",
+    "Mulgrave",
+    "3170",
+    "VIC",
+    "PEH"
+  ],
+  "033006": [
+    "WBC",
+    "Point Cook",
+    "Shp 124 Point Cook Town Cntr SC",
+    "Point Cook",
+    "3030",
+    "VIC",
+    "PEH"
+  ],
+  "033008": [
+    "WBC",
+    "South Morang",
+    "415 McDonalds Road South Morang",
+    "3752",
+    "VIC",
+    "PEH"
+  ],
+  "033010": [
+    "WBC",
+    "Airport West",
+    "Shop 58 Westfield Shp Cntr",
+    "Airport West",
+    "3042",
+    "VIC",
+    "PEH"
+  ],
+  "033012": [
+    "WBC",
+    "Epping",
+    "Shop 112-112A Epping Plaza S/C",
+    "Epping",
+    "3076",
+    "VIC",
+    "PEH"
+  ],
+  "033013": [
+    "WBC",
+    "Broadmeadows",
+    "Shop G105A Broadmeadows Shp Ctr",
+    "Broadmeadows",
+    "3047",
+    "VIC",
+    "PEH"
+  ],
+  "033019": [
+    "WBC",
+    "Northland",
+    "Tncy D001 Northland Shpng Centre",
+    "Preston East",
+    "3072",
+    "VIC",
+    "PEH"
+  ],
+  "033020": [
+    "WBC",
+    "Melbourne Cnr Bourke&ElizabethSts",
+    "360 Bourke Street",
+    "Melbourne",
+    "3000",
+    "VIC",
+    "PEH"
+  ],
+  "033021": [
+    "WBC",
+    "Brimbank",
+    "Shop T078 Brimbank Central Shp Ctr",
+    "Deer Park",
+    "3023",
+    "VIC",
+    "PEH"
+  ],
+  "033026": [
+    "WBC",
+    "Brighton",
+    "53-55 Church Street",
+    "Brighton",
+    "3186",
+    "VIC",
+    "PEH"
+  ],
+  "033027": [
+    "WBC",
+    "Werribee Plaza",
+    "Shop T71-72, Pacific Werribee S/C",
+    "Hoppers Crossing",
+    "3029",
+    "VIC",
+    "PEH"
+  ],
+  "033030": [
+    "WBC",
+    "Camberwell",
+    "586-590 Burke St",
+    "Camberwell",
+    "3124",
+    "VIC",
+    "PEH"
+  ],
+  "033042": [
+    "WBC",
+    "Craigieburn Central",
+    "COO-15 Highwal East",
+    "Craigieburn",
+    "3064",
+    "VIC",
+    "PEH"
+  ],
+  "033097": [
+    "WBC",
+    "Pakenham",
+    "Shop A Pakenham Marketplace",
+    "Pakenham",
+    "3810",
+    "VIC",
+    "PEH"
+  ],
+  "033098": [
+    "WBC",
+    "Watergardens",
+    "Shp 47 Watergardens Twn Ctr SC",
+    "Taylors Lakes",
+    "3038",
+    "VIC",
+    "PEH"
+  ],
+  "033101": [
+    "WBC",
+    "Chadstone",
+    "Shop F033 Chadstone S/C",
+    "Chadstone",
+    "3145",
+    "VIC",
+    "PEH"
+  ],
+  "033102": [
+    "WBC",
+    "Melbourne Central",
+    "Shp GD071 Melbourne Central SC",
+    "Melbourne",
+    "3000",
+    "VIC",
+    "PEH"
+  ],
+  "033104": [
+    "WBC",
+    "Eastland (Ringwood)",
+    "Shop L72 Eastland S/C",
+    "Ringwood",
+    "3134",
+    "VIC",
+    "PEH"
+  ],
+  "033108": [
+    "WBC",
+    "Keysborough",
+    "Shop Z11-Z12 Parkmore S/C",
+    "Keysborough",
+    "3173",
+    "VIC",
+    "PEH"
+  ],
+  "033109": [
+    "WBC",
+    "Fountain Gate",
+    "352 Princes Highway",
+    "Narre Warren",
+    "3805",
+    "VIC",
+    "PEH"
+  ],
+  "033110": [
+    "WBC",
+    "Geelong Westfield",
+    "Shop 1189/1190 Westfield Geelong",
+    "Geelong",
+    "3220",
+    "VIC",
+    "PEH"
+  ],
+  "033116": [
+    "WBC",
+    "Glen Waverley",
+    "Shop 133-134, The Glen Shp Cntr",
+    "Glen Waverley",
+    "3150",
+    "VIC",
+    "PEH"
+  ],
+  "033117": [
+    "WBC",
+    "Highpoint (Maribynong)",
+    "Shop 3138 Highpoint Shp Cntr",
+    "Maribyrnong",
+    "3032",
+    "VIC",
+    "PEH"
+  ],
+  "033119": [
+    "WBC",
+    "Knox City (Wantirna South)",
+    "Shop 2058 Knox City Shp Cntr",
+    "Wantirna South",
+    "3152",
+    "VIC",
+    "PEH"
+  ],
+  "033141": [
+    "WBC",
+    "Southland",
+    "Shop 2062 Westfield Southland S/C",
+    "Cheltenham",
+    "3192",
+    "VIC",
+    "PEH"
+  ],
+  "033142": [
+    "WBC",
+    "Dandenong Plaza",
+    "Shop 350A/354 Dandenong Plaza",
+    "Dandenong",
+    "3175",
+    "VIC",
+    "PEH"
+  ],
+  "033202": [
+    "WBC",
+    "Melbourne, 525 Collins St",
+    "Tenancy R05, 525 Collins Street",
+    "Melbourne",
+    "3000",
+    "VIC",
+    "PEH"
+  ],
+  "033206": [
+    "WBC",
+    "Ballarat",
+    "Shop 27-40, Central Square S/C",
+    "Ballarat",
+    "3350",
+    "VIC",
+    "PEH"
+  ],
+  "732317": [
+    "WBC",
+    "Glendale",
+    "Shop 50a Stockland Shp Cntr",
+    "Glendale",
+    "2285",
+    "NSW",
+    "PEH"
+  ],
+  "733004": [
+    "WBC",
+    "Waverley Gardens",
+    "Shops T5 & 6 Waverley Gardens S/C",
+    "Mulgrave",
+    "3170",
+    "VIC",
+    "PEH"
+  ],
+  "733006": [
+    "WBC",
+    "Point Cook",
+    "Shp 124 Point Cook Town Cntr SC",
+    "Point Cook",
+    "3030",
+    "VIC",
+    "PEH"
+  ],
+  "733008": [
+    "WBC",
+    "South Morang",
+    "415 McDonalds Road",
+    "South Morang",
+    "3752",
+    "VIC",
+    "PEH"
+  ],
+  "733010": [
+    "WBC",
+    "Airport West",
+    "Shop 58 Westfield Shp Cntr",
+    "Airport West",
+    "3042",
+    "VIC",
+    "PEH"
+  ],
+  "733012": [
+    "WBC",
+    "Epping",
+    "Shop 112-112A Epping Plaza S/C",
+    "Epping",
+    "3076",
+    "VIC",
+    "PEH"
+  ],
+  "733013": [
+    "WBC",
+    "Broadmeadows",
+    "Shop G105A Broadmeadows Shp Ctr",
+    "Broadmeadows",
+    "3047",
+    "VIC",
+    "PEH"
+  ],
+  "733019": [
+    "WBC",
+    "Northland",
+    "Tncy D001 Northland Shpng Centre",
+    "Preston East",
+    "3072",
+    "VIC",
+    "PEH"
+  ],
+  "733020": [
+    "WBC",
+    "Melbourne Cnr Bourke&ElizabethSts",
+    "360 Bourke Street",
+    "Melbourne",
+    "3000",
+    "VIC",
+    "PEH"
+  ],
+  "733021": [
+    "WBC",
+    "Brimbank",
+    "Shop T078 Brimbank Central Shp Ctr",
+    "Deer Park",
+    "3023",
+    "VIC",
+    "PEH"
+  ],
+  "733026": [
+    "WBC",
+    "Brighton",
+    "53-55 Church Street",
+    "Brighton",
+    "3186",
+    "VIC",
+    "PEH"
+  ],
+  "733027": [
+    "WBC",
+    "Werribee Plaza",
+    "Shop T71-72, Pacific Werribee S/C",
+    "Hoppers Crossing",
+    "3029",
+    "VIC",
+    "PEH"
+  ],
+  "733030": [
+    "WBC",
+    "Camberwell",
+    "586-590 Burke St",
+    "Camberwell",
+    "3124",
+    "VIC",
+    "PEH"
+  ],
+  "733042": [
+    "WBC",
+    "Craigieburn Central",
+    "COO-15 Highwal East",
+    "Craigieburn",
+    "3064",
+    "VIC",
+    "PEH"
+  ],
+  "733097": [
+    "WBC",
+    "Pakenham",
+    "Shop A Pakenham Marketplace",
+    "Pakenham",
+    "3810",
+    "VIC",
+    "PEH"
+  ],
+  "733098": [
+    "WBC",
+    "Watergardens",
+    "Shp 47 Watergardens Twn Ctr SC",
+    "Taylors Lakes",
+    "3038",
+    "VIC",
+    "PEH"
+  ],
+  "733101": [
+    "WBC",
+    "Chadstone",
+    "Shop F033 Chadstone S/C",
+    "Chadstone",
+    "3145",
+    "VIC",
+    "PEH"
+  ],
+  "733102": [
+    "WBC",
+    "Melbourne Central",
+    "Shp GD071 Melbourne Central SC",
+    "Melbourne",
+    "3000",
+    "VIC",
+    "PEH"
+  ],
+  "733104": [
+    "WBC",
+    "Eastland (Ringwood)",
+    "Shop L72 Eastland S/C",
+    "Ringwood",
+    "3134",
+    "VIC",
+    "PEH"
+  ],
+  "733108": [
+    "WBC",
+    "Keysborough",
+    "Shop Z11-Z12 Parkmore S/C",
+    "Keysborough",
+    "3173",
+    "VIC",
+    "PEH"
+  ],
+  "733109": [
+    "WBC",
+    "Fountain Gate",
+    "352 Princes Highway",
+    "Narre Warren",
+    "3805",
+    "VIC",
+    "PEH"
+  ],
+  "733110": [
+    "WBC",
+    "Geelong Westfield",
+    "Shop 1189/1190 Westfield Geelong",
+    "Geelong",
+    "3220",
+    "VIC",
+    "PEH"
+  ],
+  "733116": [
+    "WBC",
+    "Glen Waverley",
+    "Shop 133-134, The Glen Shp Cntr",
+    "Glen Waverley",
+    "3150",
+    "VIC",
+    "PEH"
+  ],
+  "733117": [
+    "WBC",
+    "Highpoint (Maribynong)",
+    "Shop 3138 Highpoint Shp Cntr",
+    "Maribyrnong",
+    "3032",
+    "VIC",
+    "PEH"
+  ],
+  "733119": [
+    "WBC",
+    "Knox City (Wantirna South)",
+    "Shop 2058 Knox City Shp Cntr",
+    "Wantirna South",
+    "3152",
+    "VIC",
+    "PEH"
+  ],
+  "733141": [
+    "WBC",
+    "Southland",
+    "Shop 2062 Westfield Southland S/C",
+    "Cheltenham",
+    "3192",
+    "VIC",
+    "PEH"
+  ],
+  "733142": [
+    "WBC",
+    "Dandenong Plaza",
+    "Shop 350A/354 Dandenong Plaza",
+    "Dandenong",
+    "3175",
+    "VIC",
+    "PEH"
+  ],
+  "733202": [
+    "WBC",
+    "Melbourne, 525 Collins St",
+    "Tenancy R05, 525 Collins Street",
+    "Melbourne",
+    "3000",
+    "VIC",
+    "PEH"
+  ],
+  "733206": [
+    "WBC",
+    "Ballarat",
+    "Shop 27-40, Central Square S/C",
+    "Ballarat",
+    "3350",
+    "VIC",
+    "PEH"
   ]
 }

--- a/lib/bsb/version.rb
+++ b/lib/bsb/version.rb
@@ -1,3 +1,3 @@
 module BSB
-  VERSION = "0.0.19"
+  VERSION = "0.0.20"
 end


### PR DESCRIPTION
Westpac have requested additions to the BSB database, as per the attached Excel file. This PR manually adds them to the DB, as an interim fix before they become available via the APN download.

[039ar_23_Urgent BSB Activation for WBC A1.xlsx](https://github.com/zeptofs/bsb/files/11607902/039ar_23_Urgent.BSB.Activation.for.WBC.A1.xlsx)
