### PR TITLE
FW-262: Fix GHA

### DIFF
--- a/.github/workflows/update_bank_branch_data.yml
+++ b/.github/workflows/update_bank_branch_data.yml
@@ -3,6 +3,7 @@ name: Update bank/branch data
 on:
   schedule:
     - cron: "0 1 * * *" # 1am UTC
+  workflow_dispatch:
 jobs:
   update_bank_branch_data:
     runs-on: ubuntu-latest
@@ -18,7 +19,7 @@ jobs:
           bundle install
           bundle exec rake bsb:update_bank_branch_data
       - name: Verify changed files
-        uses: tj-actions/verify-changed-files@v12
+        uses: tj-actions/verify-changed-files@v18
         id: verify_changed_files
         with:
           files: |
@@ -26,7 +27,7 @@ jobs:
             config/bsb_db.json
       - name: Create pull request
         if: steps.verify_changed_files.outputs.files_changed == 'true'
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           title: "Update bank/branch data"
           branch: "update-bank-branch-data"

--- a/.github/workflows/update_bank_branch_data.yml
+++ b/.github/workflows/update_bank_branch_data.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   update_bank_branch_data:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Our default permissions are no longer permissive enough to allow PR's to be created so defining them explicitly.
Also allowing the workflow to be run manually and bumping some action versions