### PR TITLE
Auto bump gem version

### DIFF
--- a/.github/workflows/update_bank_branch_data.yml
+++ b/.github/workflows/update_bank_branch_data.yml
@@ -28,6 +28,9 @@ jobs:
           files: |
             config/bsb_bank_list.json
             config/bsb_db.json
+      - name: Bump gem version
+        if: steps.verify_changed_files.outputs.files_changed == 'true'
+        run: bin/bump_gem_version
       - name: Create pull request
         if: steps.verify_changed_files.outputs.files_changed == 'true'
         uses: peter-evans/create-pull-request@v6

--- a/bin/bump_gem_version
+++ b/bin/bump_gem_version
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Used by "update_bank_branch_data" Github action to commit updated data files and bump gem version
+
+set -euo pipefail
+
+version_file_path="lib/bsb/version.rb"
+
+main() {
+  unchanging_version_part="$(current_gem_version | match_only '^\d+\.\d+\.')"
+  changing_version_part="$(current_gem_version | match_only '\d+$')"
+  new_version="$unchanging_version_part$((changing_version_part + 1))"
+  echo "Bumping to v$new_version"
+  sed -i "/VERSION/s/.*/  VERSION = \"$new_version\"/" "$version_file_path"
+}
+
+current_gem_version() {
+  git grep "VERSION" "$version_file_path" | match_only '\d+\.\d+\.\d+'
+}
+
+match_only() {
+  grep --only-matching --perl-regexp "$1"
+}
+
+main


### PR DESCRIPTION
Add automatic gem version bumps to the update_bank_branch GHA workflow (as we do with [zeptofs/bsb_nz](https://github.com/zeptofs/bsb_nz))